### PR TITLE
Fix pixsnap backend proxy port

### DIFF
--- a/pixsnap/Caddyfile
+++ b/pixsnap/Caddyfile
@@ -13,7 +13,7 @@
 
   @api path /api/*
   handle @api {
-    reverse_proxy backend:3000
+    reverse_proxy backend:4000
   }
 
   handle {


### PR DESCRIPTION
## Summary
- update the pixsnap Caddy reverse proxy so /api requests hit the backend on port 4000

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dcfec26d448328b9e9840e101e950c