### PR TITLE
Route Pixsnap through shared Caddy proxy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -53,6 +53,13 @@ workflow.sg {
     Referrer-Policy "strict-origin-when-cross-origin"
   }
 
-  reverse_proxy pixsnap:4000
+  @pixsnap-api path /api/*
+  handle @pixsnap-api {
+    reverse_proxy pixsnap-backend:4000
+  }
+
+  handle {
+    reverse_proxy pixsnap-frontend:80
+  }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,10 @@ services:
       - workflow
     restart: unless-stopped
 
-  pixsnap:
+  pixsnap-backend:
     build:
       context: ./pixsnap
-      dockerfile: Dockerfile
+      dockerfile: backend/Dockerfile
     env_file:
       - ./pixsnap/.env
     environment:
@@ -69,13 +69,26 @@ services:
       - workflow
     restart: unless-stopped
 
+  pixsnap-frontend:
+    build:
+      context: ./pixsnap/frontend
+      dockerfile: Dockerfile
+    depends_on:
+      - pixsnap-backend
+    expose:
+      - "80"
+    networks:
+      - workflow
+    restart: unless-stopped
+
   caddy:
     image: caddy:2.8-alpine
     depends_on:
       - backend
       - frontend
       - nanobanana
-      - pixsnap
+      - pixsnap-backend
+      - pixsnap-frontend
     ports:
       - "80:80"
       - "443:443"

--- a/pixsnap/backend/Dockerfile
+++ b/pixsnap/backend/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY package*.json ./
+COPY backend ./backend
+COPY frontend ./frontend
+RUN mkdir -p outputs
+EXPOSE 4000
+CMD ["node", "backend/server.js"]

--- a/pixsnap/frontend/Dockerfile
+++ b/pixsnap/frontend/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27-alpine
+COPY . /usr/share/nginx/html
+

--- a/pixsnap/frontend/config.js
+++ b/pixsnap/frontend/config.js
@@ -1,6 +1,10 @@
-﻿const DEFAULT_API_BASE_URL = 'http://localhost:4000';
+const LOCAL_DEV_PORTS = new Set(["3000", "5173", "4173"]);
+const origin = window.location.origin;
+const defaultApiHost = LOCAL_DEV_PORTS.has(window.location.port)
+  ? "http://localhost:4000"
+  : origin;
 
 export const API_BASE_URL =
   (window.__APP_CONFIG__?.apiBaseUrl && window.__APP_CONFIG__.apiBaseUrl.trim()) ||
-  DEFAULT_API_BASE_URL;
+  defaultApiHost;
 


### PR DESCRIPTION
## Summary
- split the Pixsnap stack into dedicated backend and frontend containers that share the main Docker network
- wire the root Caddyfile to proxy /api traffic to the Pixsnap backend and serve static assets from the new frontend service
- default the Pixsnap frontend to call same-origin APIs in production to avoid cross-origin failures

## Testing
- not run (docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd011780d8832887da4b7f9d0f48de