### PR TITLE
Fix Express fallback route causing backend 502 errors

### DIFF
--- a/pixsnap/backend/server.js
+++ b/pixsnap/backend/server.js
@@ -241,7 +241,7 @@ app.use((req, res, next) => {
   return serveStatic(req, res, next);
 });
 
-app.get('*', async (req, res, next) => {
+app.get(/.*/, async (req, res, next) => {
   if (req.path.startsWith('/api/')) {
     return next();
   }


### PR DESCRIPTION
## Summary
- replace the legacy `*` wildcard fallback with an Express 5 compatible matcher to serve static assets without crashing
- ensure the backend can start so the login endpoint responds with a 200 OK instead of a 502 proxy error

## Testing
- GEMINI_API_KEY=dummy node backend/server.js
- curl -i -s -X POST http://localhost:4000/api/login -H 'Content-Type: application/json' -d '{"username":"banana","password":"ilovebanana"}'


------
https://chatgpt.com/codex/tasks/task_e_68dd03c176488328915b05a91a538c05