### PR TITLE
Add design selector with modern programmer theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,18 +9,44 @@ import Footer from './components/Footer';
 import FloatingChatWidget from './components/FloatingChatWidget';
 import UseCaseLauncher from './components/UseCaseLauncher';
 import ThemeToggle from './components/ThemeToggle';
+import DesignSelector from './components/DesignSelector';
+import { useDesign } from './lib/design';
 
 const App: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const containerClassName = isModern
+    ? 'relative min-h-screen bg-slate-950 text-slate-100 font-mono transition-colors duration-300'
+    : 'min-h-screen bg-white text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100';
+
+  const headerClassName = isModern
+    ? 'flex items-center justify-between px-6 pt-8'
+    : 'flex items-center justify-between px-6 pt-6';
+
+  const controlsWrapperClassName = isModern
+    ? 'flex items-center gap-3 rounded-full border border-cyan-500/40 bg-slate-900/70 px-3 py-2 shadow-lg shadow-cyan-500/20 backdrop-blur'
+    : 'flex items-center gap-3';
+
+  const brandLinkClass = isModern
+    ? 'group flex items-center gap-3 rounded-full border border-cyan-500/40 bg-slate-950/70 px-4 py-2 text-sm font-semibold text-cyan-100 shadow-lg shadow-cyan-500/20 transition hover:border-cyan-300 hover:text-cyan-50'
+    : 'group flex items-center gap-3 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-sky-400 hover:text-sky-600 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:border-sky-400 dark:hover:text-sky-200';
+
   return (
-    <div className="min-h-screen bg-white text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+    <div className={containerClassName}>
+      {isModern && (
+        <>
+          <div className="pointer-events-none absolute inset-0 -z-20 bg-slate-950" />
+          <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[520px] bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.45),_transparent_65%)] blur-3xl" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-[420px] bg-[radial-gradient(circle_at_bottom,_rgba(16,185,129,0.35),_transparent_70%)] blur-3xl" />
+          <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(8,47,73,0.55)_0%,rgba(15,23,42,0.4)_40%,rgba(6,78,59,0.45)_100%)]" />
+        </>
+      )}
       <UseCaseLauncher />
-      <header className="flex items-center justify-between px-6 pt-6">
-        <a
-          href="#top"
-          className="group flex items-center gap-3 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-sky-400 hover:text-sky-600 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:border-sky-400 dark:hover:text-sky-200"
-        >
+      <header className={headerClassName}>
+        <a href="#top" className={brandLinkClass}>
           {/* <span className="flex h-10 w-10 items-center justify-center rounded-full border border-dashed border-slate-300 bg-slate-100 text-[10px] font-medium uppercase tracking-[0.2em] text-slate-500 transition group-hover:border-sky-400 group-hover:text-sky-600 dark:border-white/20 dark:bg-slate-900/40 dark:text-slate-400 dark:group-hover:border-sky-400 dark:group-hover:text-sky-200">
-            
+
           </span> */}
           <span className="leading-tight">
             <img
@@ -31,10 +57,13 @@ const App: React.FC = () => {
             {/* <span className="block text-xs font-normal text-slate-500 dark:text-slate-400">(replace this badge with your brand mark)</span> */}
           </span>
         </a>
-        <ThemeToggle />
+        <div className={controlsWrapperClassName}>
+          <DesignSelector />
+          <ThemeToggle />
+        </div>
       </header>
       <Hero />
-      <main className="space-y-24 pb-24">
+      <main className={isModern ? 'space-y-28 pb-32' : 'space-y-24 pb-24'}>
         <Features />
         <Showcase />
         <ChatPanel />

--- a/frontend/src/components/AdminButton.tsx
+++ b/frontend/src/components/AdminButton.tsx
@@ -1,6 +1,10 @@
-import React, { useState } from "react";
+import React, { useState } from 'react';
+import { useDesign } from '../lib/design';
 
 const AdminButton: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
 
@@ -40,21 +44,24 @@ const AdminButton: React.FC = () => {
     }
   };
 
+  const buttonClass = isModern
+    ? 'inline-flex items-center gap-2 rounded-full border border-cyan-500/40 bg-slate-950/70 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.35em] text-cyan-100 shadow-lg shadow-cyan-500/20 transition hover:border-cyan-300 hover:text-cyan-50 disabled:cursor-not-allowed disabled:opacity-60'
+    : 'inline-flex items-center gap-2 rounded-full border border-slate-300/60 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-700 shadow transition hover:border-sky-400 hover:text-sky-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10 dark:bg-white/5 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-200';
+  const messageClass =
+    status === 'error'
+      ? isModern
+        ? 'text-xs text-rose-400'
+        : 'text-xs text-rose-500 dark:text-rose-300'
+      : isModern
+        ? 'text-xs text-emerald-300'
+        : 'text-xs text-emerald-600 dark:text-emerald-300';
+
   return (
     <div className="flex flex-col items-end gap-2">
-      <button
-        type="button"
-        onClick={reindexDocuments}
-        disabled={status === 'loading'}
-        className="inline-flex items-center gap-2 rounded-full border border-slate-300/60 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-700 shadow transition hover:border-sky-400 hover:text-sky-600 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10 dark:bg-white/5 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-200"
-      >
+      <button type="button" onClick={reindexDocuments} disabled={status === 'loading'} className={buttonClass}>
         {status === 'loading' ? 'Reindexing...' : 'Admin Reindex'}
       </button>
-      {message && (
-        <p className={status === 'error' ? 'text-xs text-rose-500 dark:text-rose-300' : 'text-xs text-emerald-600 dark:text-emerald-300'}>
-          {message}
-        </p>
-      )}
+      {message && <p className={messageClass}>{message}</p>}
     </div>
   );
 };

--- a/frontend/src/components/CTA.tsx
+++ b/frontend/src/components/CTA.tsx
@@ -1,7 +1,24 @@
-﻿import React from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
+import { useDesign } from '../lib/design';
 
 const CTA: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const containerClass = isModern
+    ? 'overflow-hidden rounded-[32px] border border-cyan-500/40 bg-slate-950/70 p-8 shadow-2xl shadow-cyan-500/20 backdrop-blur sm:p-12'
+    : 'overflow-hidden rounded-[32px] border border-slate-200 bg-gradient-to-br from-sky-200/30 via-white to-slate-50 p-8 shadow-2xl shadow-slate-200/60 dark:border-white/10 dark:bg-gradient-to-br dark:from-sky-500/20 dark:via-slate-900 dark:to-slate-950 dark:shadow-sky-500/30 sm:p-12';
+  const badgeClass = isModern
+    ? 'text-[11px] font-semibold uppercase tracking-[0.4em] text-cyan-200'
+    : 'text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 dark:text-sky-200';
+  const headingClass = isModern ? 'text-3xl font-semibold text-cyan-100 sm:text-4xl' : 'text-3xl font-semibold text-slate-900 dark:text-white sm:text-4xl';
+  const descriptionClass = isModern ? 'max-w-lg text-sm text-slate-300/80' : 'max-w-lg text-sm text-slate-600 dark:text-slate-100/80';
+  const buttonClass = isModern
+    ? 'inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:from-cyan-300 hover:to-emerald-400'
+    : 'inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100';
+  const subTextClass = isModern ? 'text-xs text-slate-400' : 'text-xs text-slate-500 dark:text-slate-200/60';
+
   return (
     <section id="cta" className="mx-auto max-w-5xl px-6">
       <motion.div
@@ -9,28 +26,21 @@ const CTA: React.FC = () => {
         whileInView={{ opacity: 1, scale: 1 }}
         viewport={{ once: true, amount: 0.3 }}
         transition={{ duration: 0.6, ease: 'easeOut' }}
-        className="overflow-hidden rounded-[32px] border border-slate-200 bg-gradient-to-br from-sky-200/30 via-white to-slate-50 p-8 shadow-2xl shadow-slate-200/60 dark:border-white/10 dark:bg-gradient-to-br dark:from-sky-500/20 dark:via-slate-900 dark:to-slate-950 dark:shadow-sky-500/30 sm:p-12"
+        className={containerClass}
       >
         <div className="flex flex-col gap-6 text-center md:flex-row md:items-center md:justify-between md:text-left">
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 dark:text-sky-200">
-              ready to automate
-            </p>
-            <h3 className="text-3xl font-semibold text-slate-900 dark:text-white sm:text-4xl">
-              Start with a free workflow audit
-            </h3>
-            <p className="max-w-lg text-sm text-slate-600 dark:text-slate-100/80">
+            <p className={badgeClass}>ready to automate</p>
+            <h3 className={headingClass}>Start with a free workflow audit</h3>
+            <p className={descriptionClass}>
               Desmond Chua will review your current processes, map the quick wins, and outline how AI, custom apps, and integrations can save hours within weeks.
             </p>
           </div>
           <div className="flex flex-col items-center gap-3 md:items-end">
-            <a
-              href="mailto:desmond@workflow.sg?subject=Free%20Workflow%20Audit"
-              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
-            >
+            <a href="mailto:desmond@workflow.sg?subject=Free%20Workflow%20Audit" className={buttonClass}>
               Book your session
             </a>
-            <span className="text-xs text-slate-500 dark:text-slate-200/60">No obligation | Typical prep in under 30 minutes</span>
+            <span className={subTextClass}>No obligation | Typical prep in under 30 minutes</span>
           </div>
         </div>
       </motion.div>

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,6 +1,7 @@
-﻿import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { sendChatMessage, type ChatMessage } from '../lib/chatApi';
+import { useDesign } from '../lib/design';
 
 interface Citation {
   id: string;
@@ -10,6 +11,9 @@ interface Citation {
 }
 
 const ChatPanel: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [citations, setCitations] = useState<Citation[]>([]);
@@ -48,36 +52,74 @@ const ChatPanel: React.FC = () => {
     [messages],
   );
 
+  const containerClass = isModern
+    ? 'overflow-hidden rounded-[32px] border border-cyan-500/40 bg-slate-950/70 shadow-xl shadow-cyan-500/20 backdrop-blur'
+    : 'overflow-hidden rounded-[32px] border border-slate-200 bg-white/80 shadow-xl shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/70 dark:shadow-sky-500/20';
+  const transcriptClass = isModern
+    ? 'space-y-4 rounded-3xl border border-cyan-500/40 bg-slate-900/70 p-4 text-slate-100 shadow-inner shadow-cyan-500/20'
+    : 'space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/70';
+  const assistantBubbleClass = isModern
+    ? 'ml-auto max-w-[85%] rounded-2xl rounded-tr-none border border-cyan-500/30 bg-gradient-to-br from-cyan-500/30 via-emerald-400/20 to-cyan-500/30 px-4 py-3 text-cyan-100 shadow-cyan-500/20'
+    : 'ml-auto max-w-[85%] rounded-2xl rounded-tr-none bg-sky-100 px-4 py-3 text-sky-700 dark:bg-sky-500/20 dark:text-sky-100';
+  const userBubbleClass = isModern
+    ? 'max-w-[85%] rounded-2xl rounded-tl-none border border-cyan-500/30 bg-slate-950/70 px-4 py-3 text-slate-100 shadow-inner shadow-cyan-500/10'
+    : 'max-w-[85%] rounded-2xl rounded-tl-none bg-white px-4 py-3 text-slate-700 shadow-sm dark:bg-white/5 dark:text-slate-100';
+  const promptLabelClass = isModern
+    ? 'text-[11px] font-semibold uppercase tracking-[0.4em] text-cyan-200'
+    : 'text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400';
+  const inputClass = isModern
+    ? 'flex-1 rounded-full border border-cyan-500/40 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none focus:ring focus:ring-cyan-400/30'
+    : 'flex-1 rounded-full border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-400/20 dark:border-white/10 dark:bg-slate-900/80 dark:text-white dark:placeholder:text-slate-500';
+  const submitClass = isModern
+    ? 'inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:from-cyan-300 hover:to-emerald-400 disabled:cursor-not-allowed disabled:opacity-60'
+    : 'inline-flex items-center justify-center rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60';
+  const responsePanelClass = isModern
+    ? 'space-y-4 rounded-3xl border border-cyan-500/40 bg-slate-900/70 p-6 text-sm text-slate-100 shadow-inner shadow-cyan-500/20'
+    : 'space-y-4 rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-950/60 dark:text-slate-200';
+  const citationButtonClass = isModern
+    ? 'rounded-full border border-cyan-500/40 bg-cyan-500/10 px-3 py-1 text-xs font-medium text-cyan-100 transition hover:border-cyan-300 hover:text-cyan-200'
+    : 'rounded-full border border-sky-300 bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700 transition hover:border-sky-400 hover:text-sky-600 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100';
+  const modalBackdropClass = isModern
+    ? 'fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 px-6 py-12 backdrop-blur'
+    : 'fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-6 py-12 backdrop-blur dark:bg-slate-950/80';
+  const modalContentClass = isModern
+    ? 'max-w-2xl space-y-4 rounded-3xl border border-cyan-500/40 bg-slate-950/90 p-8 text-left text-sm text-slate-100 shadow-2xl shadow-cyan-500/30'
+    : 'max-w-2xl space-y-4 rounded-3xl border border-slate-200 bg-white p-8 text-left text-sm text-slate-700 shadow-2xl dark:border-white/10 dark:bg-slate-900/90 dark:text-slate-200';
+  const modalButtonClass = isModern
+    ? 'rounded-full border border-cyan-500/40 px-3 py-1 text-xs text-cyan-100 transition hover:border-cyan-300 hover:text-cyan-200'
+    : 'rounded-full border border-slate-200 px-3 py-1 text-xs text-slate-600 transition hover:border-sky-400 hover:text-sky-600 dark:border-white/10 dark:text-slate-300 dark:hover:border-sky-400 dark:hover:text-sky-200';
+  const modalChunkClass = isModern
+    ? 'whitespace-pre-line rounded-2xl border border-cyan-500/30 bg-slate-950/80 p-4 text-[13px] leading-relaxed text-slate-100'
+    : 'whitespace-pre-line rounded-2xl bg-slate-100 p-4 text-[13px] leading-relaxed text-slate-700 dark:bg-slate-950/80 dark:text-slate-100';
+
   return (
     <section id="chatbot" className="mx-auto max-w-6xl px-6">
-      <div className="overflow-hidden rounded-[32px] border border-slate-200 bg-white/80 shadow-xl shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/70 dark:shadow-sky-500/20">
+      <div className={containerClass}>
         <div className="grid gap-10 p-8 lg:grid-cols-[1.1fr_0.9fr]">
           <div className="space-y-6">
-            <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">Explore your automation assistant</h3>
-            <p className="text-sm text-slate-600 dark:text-slate-300">
+            <h3 className={isModern ? 'text-2xl font-semibold text-cyan-100' : 'text-2xl font-semibold text-slate-900 dark:text-white'}>Explore your automation assistant</h3>
+            <p className={isModern ? 'text-sm text-slate-300/80' : 'text-sm text-slate-600 dark:text-slate-300'}>
               Ask how we stitch together AI, n8n, and your existing tools. Responses reference the policies and SOPs you provide so stakeholders can see exactly where an answer comes from.
             </p>
-            <div className="space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/70">
+            <div className={transcriptClass}>
               <div className="space-y-3 max-h-64 overflow-y-auto pr-2 text-sm">
-                {messages.length === 0 && <p className="text-slate-500 dark:text-slate-500">No questions yet. Try asking how Workflow.sg would plug into your stack.</p>}
+                {messages.length === 0 && (
+                  <p className={isModern ? 'text-slate-400' : 'text-slate-500 dark:text-slate-500'}>No questions yet. Try asking how Workflow.sg would plug into your stack.</p>
+                )}
                 {messages.map((message, index) => (
                   <motion.div
                     key={`${message.role}-${index}-${message.content.slice(0, 8)}`}
                     initial={{ opacity: 0, y: 12 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.3, ease: 'easeOut' }}
-                    className={
-                      message.role === 'assistant'
-                        ? 'ml-auto max-w-[85%] rounded-2xl rounded-tr-none bg-sky-100 px-4 py-3 text-sky-700 dark:bg-sky-500/20 dark:text-sky-100'
-                        : 'max-w-[85%] rounded-2xl rounded-tl-none bg-white px-4 py-3 text-slate-700 shadow-sm dark:bg-white/5 dark:text-slate-100'
-                    }
+                    className={message.role === 'assistant' ? assistantBubbleClass : userBubbleClass}
                   >
                     {message.content}
                   </motion.div>
                 ))}
               </div>
               <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-                <label htmlFor="chat-input" className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">
+                <label htmlFor="chat-input" className={promptLabelClass}>
                   prompt
                 </label>
                 <div className="flex flex-col gap-3 sm:flex-row">
@@ -88,32 +130,28 @@ const ChatPanel: React.FC = () => {
                     disabled={isSubmitting}
                     onChange={(event) => setInput(event.target.value)}
                     placeholder="e.g. How do we sync WhatsApp leads into HubSpot?"
-                    className="flex-1 rounded-full border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-400/20 dark:border-white/10 dark:bg-slate-900/80 dark:text-white dark:placeholder:text-slate-500"
+                    className={inputClass}
                   />
-                  <button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="inline-flex items-center justify-center rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
+                  <button type="submit" disabled={isSubmitting} className={submitClass}>
                     {isSubmitting ? 'Thinking...' : 'Send'}
                   </button>
                 </div>
-                {error && <p className="text-xs text-rose-500 dark:text-rose-300">{error}</p>}
+                {error && <p className={isModern ? 'text-xs text-rose-400' : 'text-xs text-rose-500 dark:text-rose-300'}>{error}</p>}
               </form>
             </div>
           </div>
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300">
+              <h4 className={isModern ? 'text-[11px] font-semibold uppercase tracking-[0.35em] text-cyan-200' : 'text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300'}>
                 workflow assistant
               </h4>
-              <span className="text-xs text-slate-500">Cited responses</span>
+              <span className={isModern ? 'text-xs text-slate-400' : 'text-xs text-slate-500'}>Cited responses</span>
             </div>
-            <div className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-950/60 dark:text-slate-200">
+            <div className={responsePanelClass}>
               {latestAssistantMessage ? (
                 <p>{latestAssistantMessage}</p>
               ) : (
-                <p className="text-slate-500 dark:text-slate-500">Assistant answers will appear here along with any citations.</p>
+                <p className={isModern ? 'text-slate-400' : 'text-slate-500 dark:text-slate-500'}>Assistant answers will appear here along with any citations.</p>
               )}
               {citations.length > 0 && (
                 <div className="flex flex-wrap gap-3 pt-2">
@@ -122,7 +160,7 @@ const ChatPanel: React.FC = () => {
                       key={citation.id}
                       type="button"
                       onClick={() => setActiveCitation(citation)}
-                      className="rounded-full border border-sky-300 bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700 transition hover:border-sky-400 hover:text-sky-600 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100"
+                      className={citationButtonClass}
                     >
                       {citation.label ?? `Citation ${index + 1}`}
                     </button>
@@ -140,7 +178,7 @@ const ChatPanel: React.FC = () => {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-6 py-12 backdrop-blur dark:bg-slate-950/80"
+            className={modalBackdropClass}
             onClick={() => setActiveCitation(null)}
           >
             <motion.div
@@ -149,37 +187,31 @@ const ChatPanel: React.FC = () => {
               exit={{ y: 24, opacity: 0 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
               onClick={(event) => event.stopPropagation()}
-              className="max-w-2xl space-y-4 rounded-3xl border border-slate-200 bg-white p-8 text-left text-sm text-slate-700 shadow-2xl dark:border-white/10 dark:bg-slate-900/90 dark:text-slate-200"
+              className={modalContentClass}
             >
               <div className="flex items-center justify-between gap-4">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">source chunk</p>
+                  <p className={isModern ? 'text-[11px] font-semibold uppercase tracking-[0.4em] text-cyan-200/80' : 'text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400'}>source chunk</p>
                   {activeCitation.url ? (
                     <a
                       href={activeCitation.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-base font-semibold text-sky-600 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
+                      className={isModern ? 'text-base font-semibold text-cyan-200 hover:text-cyan-100' : 'text-base font-semibold text-sky-600 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200'}
                     >
                       {activeCitation.label ?? 'View source'}
                     </a>
                   ) : (
-                    <p className="text-base font-semibold text-sky-600 dark:text-sky-300">
+                    <p className={isModern ? 'text-base font-semibold text-cyan-100' : 'text-base font-semibold text-sky-600 dark:text-sky-300'}>
                       {activeCitation.label ?? 'Citation'}
                     </p>
                   )}
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setActiveCitation(null)}
-                  className="rounded-full border border-slate-200 px-3 py-1 text-xs text-slate-600 transition hover:border-sky-400 hover:text-sky-600 dark:border-white/10 dark:text-slate-300 dark:hover:border-sky-400 dark:hover:text-sky-200"
-                >
+                <button type="button" onClick={() => setActiveCitation(null)} className={modalButtonClass}>
                   Close
                 </button>
               </div>
-              <p className="whitespace-pre-line rounded-2xl bg-slate-100 p-4 text-[13px] leading-relaxed text-slate-700 dark:bg-slate-950/80 dark:text-slate-100">
-                {activeCitation.chunk}
-              </p>
+              <p className={modalChunkClass}>{activeCitation.chunk}</p>
             </motion.div>
           </motion.div>
         )}

--- a/frontend/src/components/DesignSelector.tsx
+++ b/frontend/src/components/DesignSelector.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useDesign } from '../lib/design';
+
+const options = [
+  {
+    value: 'classic' as const,
+    label: 'Classic',
+    description: 'Original Workflow.sg aesthetic',
+  },
+  {
+    value: 'modern-programmer' as const,
+    label: 'Modern programmer',
+    description: 'Neon terminal-inspired look',
+  },
+];
+
+const DesignSelector: React.FC = () => {
+  const { design, setDesign } = useDesign();
+
+  const containerClassName =
+    design === 'modern-programmer'
+      ? 'rounded-2xl border border-cyan-500/40 bg-slate-900/70 px-3 py-2 text-xs text-slate-200 shadow-lg shadow-cyan-500/10 backdrop-blur'
+      : 'rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 text-xs text-slate-600 shadow-sm backdrop-blur';
+
+  return (
+    <div className={containerClassName} role="group" aria-label="Select design style">
+      <div className="flex items-center gap-2">
+        {options.map((option) => {
+          const isActive = option.value === design;
+          const baseButtonClass =
+            design === 'modern-programmer'
+              ? 'rounded-xl border border-cyan-500/20 bg-slate-900/40 px-3 py-1 font-semibold transition focus:outline-none focus-visible:ring focus-visible:ring-cyan-400/40'
+              : 'rounded-xl border border-slate-200 bg-white px-3 py-1 font-semibold text-slate-700 transition focus:outline-none focus-visible:ring focus-visible:ring-sky-400/30';
+
+          const activeClass = isActive
+            ? design === 'modern-programmer'
+              ? 'border-cyan-400/60 bg-gradient-to-r from-cyan-400/40 via-emerald-400/30 to-cyan-500/30 text-cyan-100 shadow-cyan-500/30'
+              : 'border-sky-400 bg-sky-100 text-sky-700 shadow-sm'
+            : design === 'modern-programmer'
+              ? 'text-slate-300 hover:text-cyan-200'
+              : 'text-slate-500 hover:text-slate-700';
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={`${baseButtonClass} ${activeClass}`}
+              onClick={() => setDesign(option.value)}
+              aria-pressed={isActive}
+            >
+              <span className="block text-[11px] uppercase tracking-[0.25em]">{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-[10px] leading-relaxed opacity-80">
+        {options.find((option) => option.value === design)?.description}
+      </p>
+    </div>
+  );
+};
+
+export default DesignSelector;

--- a/frontend/src/components/Features.tsx
+++ b/frontend/src/components/Features.tsx
@@ -1,6 +1,7 @@
-﻿import React from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import SectionHeader from './SectionHeader';
+import { useDesign } from '../lib/design';
 
 const features = [
   {
@@ -36,6 +37,20 @@ const features = [
 ];
 
 const Features: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const cardClass = isModern
+    ? 'relative overflow-hidden rounded-3xl border border-cyan-500/30 bg-slate-900/60 p-6 text-slate-100 shadow-lg shadow-cyan-500/15 backdrop-blur'
+    : 'relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/50 dark:shadow-black/20';
+  const cardBorderClass = isModern
+    ? 'absolute inset-px rounded-[22px] border border-cyan-500/30'
+    : 'absolute inset-px rounded-[22px] border border-white/60 dark:border-white/5';
+  const iconClass = isModern
+    ? 'inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500/30 via-emerald-400/20 to-cyan-500/30 text-sm font-semibold tracking-[0.1em] text-cyan-100 shadow-inner shadow-cyan-500/30'
+    : 'inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-sky-100 text-sm font-semibold tracking-[0.1em] text-sky-700 dark:bg-sky-500/20 dark:text-sky-200';
+  const descriptionClass = isModern ? 'text-sm text-slate-300/80' : 'text-sm text-slate-600 dark:text-slate-300';
+
   return (
     <section id="features" className="mx-auto max-w-6xl px-6">
       <div className="space-y-12">
@@ -52,16 +67,14 @@ const Features: React.FC = () => {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.3 }}
               transition={{ delay: index * 0.05, duration: 0.6, ease: 'easeOut' }}
-              className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/50 dark:shadow-black/20"
+              className={cardClass}
             >
-              <div className="absolute inset-px rounded-[22px] border border-white/60 dark:border-white/5" />
+              <div className={cardBorderClass} />
               <div className="relative flex h-full flex-col gap-4">
-                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-sky-100 text-sm font-semibold tracking-[0.1em] text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">
-                  {feature.icon}
-                </span>
+                <span className={iconClass}>{feature.icon}</span>
                 <div className="space-y-2">
-                  <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{feature.title}</h3>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
+                  <h3 className={isModern ? 'text-xl font-semibold text-cyan-100' : 'text-xl font-semibold text-slate-900 dark:text-white'}>{feature.title}</h3>
+                  <p className={descriptionClass}>{feature.description}</p>
                 </div>
               </div>
             </motion.div>

--- a/frontend/src/components/FloatingChatWidget.tsx
+++ b/frontend/src/components/FloatingChatWidget.tsx
@@ -1,8 +1,12 @@
-﻿import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { sendChatMessage, type ChatMessage } from '../lib/chatApi';
+import { useDesign } from '../lib/design';
 
 const FloatingChatWidget: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
   const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -57,6 +61,32 @@ const FloatingChatWidget: React.FC = () => {
     });
   }, []);
 
+  const panelClass = isModern
+    ? 'w-[320px] sm:w-[360px] rounded-3xl border border-cyan-500/40 bg-slate-950/90 p-4 text-sm text-slate-100 shadow-2xl shadow-cyan-500/30 backdrop-blur'
+    : 'w-[320px] sm:w-[360px] rounded-3xl border border-slate-200 bg-white p-4 text-sm text-slate-800 shadow-2xl shadow-slate-300/60 backdrop-blur dark:border-white/10 dark:bg-slate-900/95 dark:text-slate-100';
+  const transcriptClass = isModern
+    ? 'mt-4 flex h-60 flex-col overflow-hidden rounded-2xl border border-cyan-500/40 bg-slate-950/70'
+    : 'mt-4 flex h-60 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 dark:border-white/5 dark:bg-slate-950/70';
+  const assistantBubbleClass = isModern
+    ? 'ml-auto max-w-[85%] rounded-2xl rounded-tr-none border border-cyan-500/30 bg-gradient-to-br from-cyan-500/30 via-emerald-400/20 to-cyan-500/30 px-3 py-2 text-cyan-100 shadow-cyan-500/20'
+    : 'ml-auto max-w-[85%] rounded-2xl rounded-tr-none bg-sky-100 px-3 py-2 text-sky-700 dark:bg-sky-500/20 dark:text-sky-100';
+  const userBubbleClass = isModern
+    ? 'max-w-[85%] rounded-2xl rounded-tl-none border border-cyan-500/30 bg-slate-950/70 px-3 py-2 text-slate-100 shadow-inner shadow-cyan-500/10'
+    : 'max-w-[85%] rounded-2xl rounded-tl-none bg-white px-3 py-2 text-slate-700 shadow-sm dark:bg-white/5 dark:text-slate-100';
+  const inputClass = isModern
+    ? 'flex-1 rounded-full border border-cyan-500/40 bg-slate-950/80 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-cyan-400 focus:outline-none focus:ring focus:ring-cyan-400/30'
+    : 'flex-1 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs text-slate-800 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-400/20 dark:border-white/10 dark:bg-slate-950/80 dark:text-white dark:placeholder:text-slate-500';
+  const submitClass = isModern
+    ? 'inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500 px-3 py-2 text-xs font-semibold text-slate-900 transition hover:from-cyan-300 hover:to-emerald-400 disabled:cursor-not-allowed disabled:opacity-60'
+    : 'inline-flex items-center justify-center rounded-full bg-sky-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60';
+  const toggleButtonClass = isModern
+    ? 'inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500 px-5 py-3 text-sm font-semibold text-slate-900 shadow-xl shadow-cyan-500/30 transition hover:from-cyan-300 hover:to-emerald-400 focus:outline-none focus:ring focus:ring-cyan-500/40'
+    : 'inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-xl shadow-sky-500/30 transition hover:bg-sky-400 focus:outline-none focus:ring focus:ring-sky-500/30';
+  const closeButtonClass = isModern
+    ? 'rounded-full border border-cyan-500/40 px-2 py-1 text-xs text-cyan-100 transition hover:border-cyan-300 hover:text-cyan-200'
+    : 'rounded-full border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:border-sky-400 hover:text-sky-600 dark:border-white/10 dark:text-slate-300 dark:hover:border-sky-400 dark:hover:text-sky-100';
+  const errorClass = isModern ? 'mt-2 text-xs text-rose-400' : 'mt-2 text-xs text-rose-500 dark:text-rose-300';
+
   return (
     <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
       <AnimatePresence>
@@ -67,36 +97,28 @@ const FloatingChatWidget: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 8 }}
             transition={{ duration: 0.2, ease: 'easeOut' }}
-            className="w-[320px] sm:w-[360px] rounded-3xl border border-slate-200 bg-white p-4 text-sm text-slate-800 shadow-2xl shadow-slate-300/60 backdrop-blur dark:border-white/10 dark:bg-slate-900/95 dark:text-slate-100"
+            className={panelClass}
           >
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">Workflow.sg Assistant</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">Powered by OpenAI</p>
+                <p className={isModern ? 'text-sm font-semibold text-cyan-100' : 'text-sm font-semibold text-slate-900 dark:text-white'}>Workflow.sg Assistant</p>
+                <p className={isModern ? 'text-xs text-slate-400' : 'text-xs text-slate-500 dark:text-slate-400'}>Powered by OpenAI</p>
               </div>
-              <button
-                type="button"
-                onClick={toggleWidget}
-                className="rounded-full border border-slate-200 px-2 py-1 text-xs text-slate-600 transition hover:border-sky-400 hover:text-sky-600 dark:border-white/10 dark:text-slate-300 dark:hover:border-sky-400 dark:hover:text-sky-100"
-              >
+              <button type="button" onClick={toggleWidget} className={closeButtonClass}>
                 Close
               </button>
             </div>
-            <div className="mt-4 flex h-60 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 dark:border-white/5 dark:bg-slate-950/70">
+            <div className={transcriptClass}>
               <div className="flex-1 space-y-3 overflow-y-auto p-3">
                 {messages.length === 0 && (
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                  <p className={isModern ? 'text-xs text-slate-500' : 'text-xs text-slate-500 dark:text-slate-400'}>
                     Ask anything about Workflow.sg and the assistant will help.
                   </p>
                 )}
                 {messages.map((message, index) => (
                   <div
                     key={`${message.role}-${index}-${message.content.slice(0, 8)}`}
-                    className={
-                      message.role === 'assistant'
-                        ? 'ml-auto max-w-[85%] rounded-2xl rounded-tr-none bg-sky-100 px-3 py-2 text-sky-700 dark:bg-sky-500/20 dark:text-sky-100'
-                        : 'max-w-[85%] rounded-2xl rounded-tl-none bg-white px-3 py-2 text-slate-700 shadow-sm dark:bg-white/5 dark:text-slate-100'
-                    }
+                    className={message.role === 'assistant' ? assistantBubbleClass : userBubbleClass}
                   >
                     {message.content}
                   </div>
@@ -112,25 +134,17 @@ const FloatingChatWidget: React.FC = () => {
                 disabled={isSubmitting}
                 onChange={(event) => setInput(event.target.value)}
                 placeholder="Type your question"
-                className="flex-1 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs text-slate-800 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-400/20 dark:border-white/10 dark:bg-slate-950/80 dark:text-white dark:placeholder:text-slate-500"
+                className={inputClass}
               />
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="inline-flex items-center justify-center rounded-full bg-sky-500 px-3 py-2 text-xs font-semibold text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
-              >
+              <button type="submit" disabled={isSubmitting} className={submitClass}>
                 {isSubmitting ? 'Sending...' : 'Send'}
               </button>
             </form>
-            {error && <p className="mt-2 text-xs text-rose-500 dark:text-rose-300">{error}</p>}
+            {error && <p className={errorClass}>{error}</p>}
           </motion.div>
         )}
       </AnimatePresence>
-      <button
-        type="button"
-        onClick={toggleWidget}
-        className="inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-xl shadow-sky-500/30 transition hover:bg-sky-400 focus:outline-none focus:ring focus:ring-sky-500/30"
-      >
+      <button type="button" onClick={toggleWidget} className={toggleButtonClass}>
         {isOpen ? 'Hide assistant' : 'Chat with Workflow.sg'}
       </button>
     </div>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,28 +1,42 @@
-﻿import React from 'react';
+import React from 'react';
+import { useDesign } from '../lib/design';
 
 const Footer: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const footerClass = isModern
+    ? 'border-t border-cyan-500/30 bg-slate-950/80 backdrop-blur'
+    : 'border-t border-slate-200 bg-slate-50 dark:border-white/5 dark:bg-slate-950/80';
+  const brandClass = isModern ? 'text-sm font-semibold tracking-tight text-cyan-100' : 'text-sm font-semibold tracking-tight text-slate-900 dark:text-white';
+  const descriptionClass = isModern ? 'text-xs text-slate-400' : 'text-xs text-slate-600 dark:text-slate-400';
+  const linkClass = isModern
+    ? 'transition hover:text-cyan-200 text-xs text-slate-400'
+    : 'transition hover:text-sky-600 text-xs text-slate-500 dark:text-slate-400 dark:hover:text-sky-300';
+  const copyrightClass = isModern ? 'text-xs text-slate-500' : 'text-xs text-slate-500 dark:text-slate-500';
+
   return (
-    <footer className="border-t border-slate-200 bg-slate-50 dark:border-white/5 dark:bg-slate-950/80">
+    <footer className={footerClass}>
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-sm font-semibold tracking-tight text-slate-900 dark:text-white">Workflow.sg</p>
-          <p className="text-xs text-slate-600 dark:text-slate-400">AI automation, custom web apps, and process design for SMEs in Singapore.</p>
+          <p className={brandClass}>Workflow.sg</p>
+          <p className={descriptionClass}>AI automation, custom web apps, and process design for SMEs in Singapore.</p>
         </div>
-        <div className="flex flex-wrap items-center gap-6 text-xs text-slate-500 dark:text-slate-400">
-          <a className="transition hover:text-sky-600 dark:hover:text-sky-300" href="#features">
+        <div className="flex flex-wrap items-center gap-6">
+          <a className={linkClass} href="#features">
             Capabilities
           </a>
-          <a className="transition hover:text-sky-600 dark:hover:text-sky-300" href="#showcase">
+          <a className={linkClass} href="#showcase">
             Use case
           </a>
-          <a className="transition hover:text-sky-600 dark:hover:text-sky-300" href="#testimonials">
+          <a className={linkClass} href="#testimonials">
             Outcomes
           </a>
-          <a className="transition hover:text-sky-600 dark:hover:text-sky-300" href="#cta">
+          <a className={linkClass} href="#cta">
             Free audit
           </a>
         </div>
-        <p className="text-xs text-slate-500 dark:text-slate-500">© {new Date().getFullYear()} Workflow.sg. All rights reserved.</p>
+        <p className={copyrightClass}>© {new Date().getFullYear()} Workflow.sg. All rights reserved.</p>
       </div>
     </footer>
   );

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,6 +1,7 @@
-﻿import React from 'react';
+import React from 'react';
 import { motion, type Variants } from 'framer-motion';
 import AdminButton from './AdminButton';
+import { useDesign } from '../lib/design';
 
 const containerVariants: Variants = {
   hidden: { opacity: 0, y: 32 },
@@ -12,34 +13,68 @@ const containerVariants: Variants = {
 };
 
 const Hero: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const backgroundGlowClass = isModern
+    ? 'pointer-events-none absolute inset-x-0 top-0 -z-10 h-[520px] bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.45),_transparent_70%)]'
+    : 'pointer-events-none absolute inset-x-0 top-0 -z-10 h-[520px] bg-gradient-to-b from-sky-200/40 via-white to-slate-100 blur-3xl dark:from-sky-500/20 dark:via-slate-900 dark:to-slate-950';
+  const badgeClass = isModern
+    ? 'inline-flex items-center rounded-full border border-cyan-400/60 bg-slate-900/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-cyan-200 shadow-lg shadow-cyan-500/20 backdrop-blur'
+    : 'inline-flex items-center rounded-full border border-sky-300/50 bg-sky-100 px-4 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-sky-600 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400';
+  const headingClass = isModern
+    ? 'bg-gradient-to-r from-cyan-200 via-emerald-200 to-cyan-100 bg-clip-text text-4xl font-semibold tracking-tight text-transparent sm:text-5xl md:text-6xl'
+    : 'text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl md:text-6xl dark:text-white';
+  const descriptionClass = isModern
+    ? 'mx-auto max-w-2xl text-base text-slate-300/80 sm:text-lg'
+    : 'mx-auto max-w-2xl text-base text-slate-600 sm:text-lg dark:text-slate-300';
+  const primaryCtaClass = isModern
+    ? 'inline-flex items-center justify-center rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500 px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-cyan-500/30 transition hover:from-cyan-300 hover:to-emerald-400'
+    : 'inline-flex items-center justify-center rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-400';
+  const secondaryCtaClass = isModern
+    ? 'inline-flex items-center justify-center rounded-full border border-cyan-500/60 px-6 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-400 hover:text-cyan-200'
+    : 'inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-sky-400/60 hover:text-sky-600 dark:border-white/10 dark:text-slate-100 dark:hover:border-sky-400/60 dark:hover:text-sky-300';
+  const featureCardClass = isModern
+    ? 'relative w-full max-w-4xl overflow-hidden rounded-3xl border border-cyan-500/40 bg-slate-900/70 shadow-2xl shadow-cyan-500/20 backdrop-blur'
+    : 'relative w-full max-w-4xl overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-200/60 dark:border-white/10 dark:bg-slate-900/60 dark:shadow-sky-500/20';
+  const featureHighlightClass = isModern
+    ? 'absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.25),_transparent_65%)]'
+    : 'absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.15),transparent_60%)] dark:bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.25),transparent_60%)]';
+  const insightCardClass = isModern
+    ? 'relative w-full overflow-hidden rounded-2xl border border-cyan-500/40 bg-slate-900/60 p-6 text-cyan-100 shadow-lg shadow-cyan-500/20'
+    : 'relative w-full overflow-hidden rounded-2xl border border-sky-200 bg-sky-50/70 p-6 text-slate-700 shadow-sm dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-slate-100';
+  const listAccentClass = isModern ? 'bg-emerald-400' : 'bg-emerald-500';
+  const statsCardClass = isModern
+    ? 'rounded-2xl border border-cyan-500/30 bg-slate-900/60 p-4'
+    : 'rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/60';
+  const statsLabelClass = isModern
+    ? 'text-xs font-semibold uppercase tracking-[0.35em] text-cyan-200'
+    : 'text-sm font-semibold uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300';
+  const statsBodyClass = isModern
+    ? 'mt-4 space-y-2 text-xs text-slate-300/80'
+    : 'mt-4 space-y-2 text-xs text-slate-500 dark:text-slate-400';
+  const statsPillClass = isModern
+    ? 'rounded-full bg-gradient-to-r from-cyan-400/30 to-emerald-400/30 px-3 py-1 text-xs font-medium text-cyan-100'
+    : 'rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700 dark:bg-sky-500/20 dark:text-sky-300';
+
   return (
     <section className="relative overflow-hidden">
-      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[520px] bg-gradient-to-b from-sky-200/40 via-white to-slate-100 blur-3xl dark:from-sky-500/20 dark:via-slate-900 dark:to-slate-950" />
+      <div className={backgroundGlowClass} />
       <div className="mx-auto flex max-w-6xl flex-col items-center gap-12 px-6 pt-6 sm:pt-10">
         <div className="flex w-full justify-end">
           <AdminButton />
         </div>
         <motion.div initial="hidden" animate="visible" variants={containerVariants} className="space-y-6 text-center">
-          <span className="inline-flex items-center rounded-full border border-sky-300/50 bg-sky-100 px-4 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-sky-600 dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-sky-400">
-            Workflow.sg
-          </span>
-          <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl md:text-6xl dark:text-white">
-            AI automation that pays for itself within weeks
-          </h1>
-          <p className="mx-auto max-w-2xl text-base text-slate-600 sm:text-lg dark:text-slate-300">
+          <span className={badgeClass}>Workflow.sg</span>
+          <h1 className={headingClass}>AI automation that pays for itself within weeks</h1>
+          <p className={descriptionClass}>
             Workflow.sg helps SMEs in Singapore save time, cut costs, and boost productivity with AI-powered automation, custom web apps, and smart process design. We integrate with the tools you already use so results show up in days—not quarters.
           </p>
           <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-            <a
-              href="#cta"
-              className="inline-flex items-center justify-center rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-400"
-            >
+            <a href="#cta" className={primaryCtaClass}>
               Book a free workflow audit
             </a>
-            <a
-              href="#features"
-              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-sky-400/60 hover:text-sky-600 dark:border-white/10 dark:text-slate-100 dark:hover:border-sky-400/60 dark:hover:text-sky-300"
-            >
+            <a href="#features" className={secondaryCtaClass}>
               Explore what we automate
             </a>
           </div>
@@ -48,34 +83,34 @@ const Hero: React.FC = () => {
           initial={{ opacity: 0, y: 40 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.8, ease: 'easeOut' }}
-          className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-200/60 dark:border-white/10 dark:bg-slate-900/60 dark:shadow-sky-500/20"
+          className={featureCardClass}
         >
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.15),transparent_60%)] dark:bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.25),transparent_60%)]" />
+          <div className={featureHighlightClass} />
           <div className="relative grid gap-6 p-8 text-left sm:grid-cols-2 sm:p-10">
             <div className="space-y-3">
-              <p className="text-sm font-semibold text-sky-600 dark:text-sky-300">Automation built around your business</p>
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">From triaging emails to guiding your team</h3>
-              <p className="text-sm text-slate-600 dark:text-slate-300">
+              <p className={isModern ? 'text-sm font-semibold text-cyan-200' : 'text-sm font-semibold text-sky-600 dark:text-sky-300'}>Automation built around your business</p>
+              <h3 className={isModern ? 'text-xl font-semibold text-cyan-100' : 'text-xl font-semibold text-slate-900 dark:text-white'}>From triaging emails to guiding your team</h3>
+              <p className={isModern ? 'text-sm text-slate-300/80' : 'text-sm text-slate-600 dark:text-slate-300'}>
                 We remove repetitive tasks across email, WhatsApp, forms, and back-office systems. Every workflow is mapped first, then automated with AI that cites sources for accuracy and keeps your team in control.
               </p>
-              <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
-                <li className="flex items-start gap-2"><span className="mt-1 h-2 w-2 rounded-full bg-emerald-500" /><span>Custom web apps built on React and Node.js that fit seamlessly into existing operations.</span></li>
-                <li className="flex items-start gap-2"><span className="mt-1 h-2 w-2 rounded-full bg-emerald-500" /><span>Policy-aware chatbots with retrieval-augmented generation and citations.</span></li>
-                <li className="flex items-start gap-2"><span className="mt-1 h-2 w-2 rounded-full bg-emerald-500" /><span>WhatsApp journeys that capture, qualify, and hand over leads instantly.</span></li>
+              <ul className={isModern ? 'space-y-2 text-sm text-slate-300/80' : 'space-y-2 text-sm text-slate-600 dark:text-slate-300'}>
+                <li className="flex items-start gap-2"><span className={`mt-1 h-2 w-2 rounded-full ${listAccentClass}`} /><span>Custom web apps built on React and Node.js that fit seamlessly into existing operations.</span></li>
+                <li className="flex items-start gap-2"><span className={`mt-1 h-2 w-2 rounded-full ${listAccentClass}`} /><span>Policy-aware chatbots with retrieval-augmented generation and citations.</span></li>
+                <li className="flex items-start gap-2"><span className={`mt-1 h-2 w-2 rounded-full ${listAccentClass}`} /><span>WhatsApp journeys that capture, qualify, and hand over leads instantly.</span></li>
               </ul>
             </div>
             <div className="flex flex-col gap-4">
-              <div className="relative w-full overflow-hidden rounded-2xl border border-sky-200 bg-sky-50/70 p-6 text-slate-700 shadow-sm dark:border-sky-500/30 dark:bg-sky-500/10 dark:text-slate-100">
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 dark:text-sky-300">Real outcomes</p>
+              <div className={insightCardClass}>
+                <p className={isModern ? 'text-[11px] font-semibold uppercase tracking-[0.35em] text-cyan-200' : 'text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 dark:text-sky-300'}>Real outcomes</p>
                 <ul className="mt-4 space-y-3 text-sm">
-                  <li className="flex items-start gap-2"><span className="mt-1 h-2 w-2 rounded-full bg-sky-500" /><span>Lead capture to instant reply to sales handover in a single flow.</span></li>
-                  <li className="flex items-start gap-2"><span className="mt-1 h-2 w-2 rounded-full bg-sky-500" /><span>Policy-aware Q&amp;A from PDFs and Word docs with source citations.</span></li>
-                  <li className="flex items-start gap-2"><span className="mt-1 h-2 w-2 rounded-full bg-sky-500" /><span>Operations updates that keep projects on track with fewer reminders.</span></li>
+                  <li className="flex items-start gap-2"><span className={`mt-1 h-2 w-2 rounded-full ${isModern ? 'bg-cyan-400' : 'bg-sky-500'}`} /><span>Lead capture to instant reply to sales handover in a single flow.</span></li>
+                  <li className="flex items-start gap-2"><span className={`mt-1 h-2 w-2 rounded-full ${isModern ? 'bg-cyan-400' : 'bg-sky-500'}`} /><span>Policy-aware Q&amp;A from PDFs and Word docs with source citations.</span></li>
+                  <li className="flex items-start gap-2"><span className={`mt-1 h-2 w-2 rounded-full ${isModern ? 'bg-cyan-400' : 'bg-sky-500'}`} /><span>Operations updates that keep projects on track with fewer reminders.</span></li>
                 </ul>
               </div>
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/60">
-                <div className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">Our 5-step playbook</div>
-                <div className="mt-4 space-y-2 text-xs text-slate-500 dark:text-slate-400">
+              <div className={statsCardClass}>
+                <div className={statsLabelClass}>Our 5-step playbook</div>
+                <div className={statsBodyClass}>
                   <p>1. Discovery – identify bottlenecks and success metrics.</p>
                   <p>2. Design – map workflows and integrations.</p>
                   <p>3. Build – rapid prototyping with your data.</p>
@@ -83,9 +118,7 @@ const Hero: React.FC = () => {
                   <p>5. Scale – expand automation once ROI is proven.</p>
                 </div>
                 <div className="mt-6 flex justify-end">
-                  <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700 dark:bg-sky-500/20 dark:text-sky-300">
-                    Typical payback: weeks, not months
-                  </span>
+                  <span className={statsPillClass}>Typical payback: weeks, not months</span>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/SectionHeader.tsx
+++ b/frontend/src/components/SectionHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useDesign } from "../lib/design";
 
 interface SectionHeaderProps {
   eyebrow?: string;
@@ -8,17 +9,27 @@ interface SectionHeaderProps {
 }
 
 const SectionHeader: React.FC<SectionHeaderProps> = ({ eyebrow, title, description, align = "center" }) => {
+  const { design } = useDesign();
+  const isModern = design === "modern-programmer";
+
   const alignment = align === "center" ? "mx-auto text-center" : "text-left";
+  const eyebrowClass = isModern
+    ? "text-[11px] font-semibold uppercase tracking-[0.4em] text-emerald-300/80"
+    : "text-sm font-semibold uppercase tracking-[0.2em] text-sky-600 dark:text-sky-400";
+  const titleClass = isModern
+    ? "bg-gradient-to-r from-cyan-300 via-emerald-300 to-cyan-200 bg-clip-text text-3xl font-semibold tracking-tight text-transparent sm:text-4xl"
+    : "text-3xl font-semibold tracking-tight text-slate-900 transition-colors duration-300 dark:text-white sm:text-4xl";
+  const descriptionClass = isModern
+    ? "text-base text-slate-300/80 transition-colors duration-300 sm:text-lg"
+    : "text-base text-slate-600 transition-colors duration-300 dark:text-slate-300 sm:text-lg";
 
   return (
     <div className={`max-w-2xl ${alignment} space-y-3`}>
       {eyebrow && (
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-600 dark:text-sky-400">{eyebrow}</p>
+        <p className={eyebrowClass}>{eyebrow}</p>
       )}
-      <h2 className="text-3xl font-semibold tracking-tight text-slate-900 transition-colors duration-300 dark:text-white sm:text-4xl">
-        {title}
-      </h2>
-      {description && <p className="text-base text-slate-600 transition-colors duration-300 dark:text-slate-300 sm:text-lg">{description}</p>}
+      <h2 className={titleClass}>{title}</h2>
+      {description && <p className={descriptionClass}>{description}</p>}
     </div>
   );
 };

--- a/frontend/src/components/Showcase.tsx
+++ b/frontend/src/components/Showcase.tsx
@@ -1,6 +1,7 @@
-﻿import React from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import SectionHeader from './SectionHeader';
+import { useDesign } from '../lib/design';
 
 const mockSteps = [
   {
@@ -18,9 +19,34 @@ const mockSteps = [
 ];
 
 const Showcase: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const containerClass = isModern
+    ? 'overflow-hidden rounded-[40px] border border-cyan-500/40 bg-slate-950/60 shadow-2xl shadow-cyan-500/20 backdrop-blur'
+    : 'overflow-hidden rounded-[40px] border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-slate-100 shadow-2xl shadow-slate-200/60 dark:border-white/10 dark:bg-gradient-to-br dark:from-slate-900 dark:via-slate-950 dark:to-slate-950 dark:shadow-sky-500/20';
+  const stepCardClass = isModern
+    ? 'rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-4 shadow-inner shadow-cyan-500/10 backdrop-blur'
+    : 'rounded-3xl border border-slate-200 bg-white/70 p-4 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5';
+  const mainCardClass = isModern
+    ? 'relative w-full max-w-md overflow-hidden rounded-3xl border border-cyan-500/30 bg-slate-900/70 p-6 shadow-xl shadow-cyan-500/20 backdrop-blur'
+    : 'relative w-full max-w-md overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/80 dark:shadow-black/30';
+  const messageCardClass = isModern
+    ? 'space-y-2 rounded-2xl border border-cyan-500/40 bg-slate-900/60 p-4 text-slate-100 shadow-inner shadow-cyan-500/20'
+    : 'space-y-2 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/60';
+  const metricCardClass = isModern
+    ? 'rounded-2xl border border-cyan-500/40 bg-slate-900/60 p-4 text-xs text-cyan-100 shadow-inner shadow-cyan-500/20'
+    : 'rounded-2xl border border-slate-200 bg-slate-50 p-4 text-xs text-slate-500 dark:border-white/10 dark:bg-slate-950/40 dark:text-slate-400';
+  const progressClass = isModern
+    ? 'h-full rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500'
+    : 'h-full rounded-full bg-gradient-to-r from-sky-400 to-emerald-400';
+  const calloutClass = isModern
+    ? 'rounded-2xl border border-cyan-500/40 bg-slate-900/60 p-4 text-xs text-cyan-100 shadow-inner shadow-cyan-500/20'
+    : 'rounded-2xl border border-sky-200 bg-sky-50 p-4 text-xs text-sky-700 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100';
+
   return (
     <section id="showcase" className="mx-auto max-w-6xl px-6">
-      <div className="overflow-hidden rounded-[40px] border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-slate-100 shadow-2xl shadow-slate-200/60 dark:border-white/10 dark:bg-gradient-to-br dark:from-slate-900 dark:via-slate-950 dark:to-slate-950 dark:shadow-sky-500/20">
+      <div className={containerClass}>
         <div className="grid gap-10 p-8 sm:grid-cols-2 sm:p-12">
           <div className="space-y-8">
             <SectionHeader
@@ -37,12 +63,12 @@ const Showcase: React.FC = () => {
                   whileInView={{ opacity: 1, x: 0 }}
                   viewport={{ once: true, amount: 0.2 }}
                   transition={{ delay: index * 0.08, duration: 0.5, ease: 'easeOut' }}
-                  className="rounded-3xl border border-slate-200 bg-white/70 p-4 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5"
+                  className={stepCardClass}
                 >
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-600 dark:text-sky-300">
+                  <p className={isModern ? 'text-[11px] font-semibold uppercase tracking-[0.35em] text-cyan-200' : 'text-xs font-semibold uppercase tracking-[0.2em] text-sky-600 dark:text-sky-300'}>
                     {step.label}
                   </p>
-                  <p className="mt-2 text-sm text-slate-700 dark:text-slate-100">{step.content}</p>
+                  <p className={isModern ? 'mt-2 text-sm text-slate-200/80' : 'mt-2 text-sm text-slate-700 dark:text-slate-100'}>{step.content}</p>
                 </motion.div>
               ))}
             </div>
@@ -54,37 +80,43 @@ const Showcase: React.FC = () => {
             transition={{ duration: 0.6, ease: 'easeOut' }}
             className="relative flex items-center justify-center"
           >
-            <div className="relative w-full max-w-md overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/80 dark:shadow-black/30">
+            <div className={mainCardClass}>
               <div className="grid gap-4">
-                <div className="space-y-2 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/60">
-                  <p className="text-xs font-medium text-slate-500 dark:text-slate-400">assistant</p>
-                  <p className="text-sm text-slate-700 dark:text-slate-100">
+                <div className={messageCardClass}>
+                  <p className={isModern ? 'text-xs font-medium text-cyan-200/90' : 'text-xs font-medium text-slate-500 dark:text-slate-400'}>assistant</p>
+                  <p className={isModern ? 'text-sm text-slate-100/90' : 'text-sm text-slate-700 dark:text-slate-100'}>
                     Hi Jasmine! Thanks for reaching out about automating scheduling. Based on your policies, the SME bundle fits best at $280/month. I can connect you with Desmond for a walkthrough at 3pm or 5pm today—what works?
                   </p>
-                  <div className="flex flex-wrap items-center gap-2 pt-2 text-[11px] text-sky-700 dark:text-sky-300">
-                    <span className="rounded-full border border-sky-300 bg-sky-100 px-2 py-1 dark:border-sky-500/40 dark:bg-sky-500/10">pricing-guide.pdf</span>
-                    <span className="rounded-full border border-sky-300 bg-sky-100 px-2 py-1 dark:border-sky-500/40 dark:bg-sky-500/10">service-policies.docx</span>
+                  <div className={isModern ? 'flex flex-wrap items-center gap-2 pt-2 text-[11px] text-cyan-200/80' : 'flex flex-wrap items-center gap-2 pt-2 text-[11px] text-sky-700 dark:text-sky-300'}>
+                    <span className={isModern ? 'rounded-full border border-cyan-400/40 bg-cyan-400/10 px-2 py-1' : 'rounded-full border border-sky-300 bg-sky-100 px-2 py-1 dark:border-sky-500/40 dark:bg-sky-500/10'}>pricing-guide.pdf</span>
+                    <span className={isModern ? 'rounded-full border border-cyan-400/40 bg-cyan-400/10 px-2 py-1' : 'rounded-full border border-sky-300 bg-sky-100 px-2 py-1 dark:border-sky-500/40 dark:bg-sky-500/10'}>service-policies.docx</span>
                   </div>
                 </div>
-                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-xs text-slate-500 dark:border-white/10 dark:bg-slate-950/40 dark:text-slate-400">
-                  <p className="font-semibold uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300">time saved</p>
-                  <div className="mt-2 h-2 rounded-full bg-slate-200 dark:bg-slate-800">
+                <div className={metricCardClass}>
+                  <p className={isModern ? 'font-semibold uppercase tracking-[0.35em] text-cyan-200' : 'font-semibold uppercase tracking-[0.3em] text-slate-600 dark:text-slate-300'}>time saved</p>
+                  <div className={isModern ? 'mt-3 h-2 rounded-full bg-slate-800' : 'mt-2 h-2 rounded-full bg-slate-200 dark:bg-slate-800'}>
                     <motion.div
                       initial={{ width: '0%' }}
                       whileInView={{ width: '92%' }}
                       viewport={{ once: true }}
                       transition={{ duration: 0.8, ease: 'easeOut', delay: 0.2 }}
-                      className="h-full rounded-full bg-gradient-to-r from-sky-400 to-emerald-400"
+                      className={progressClass}
                     />
                   </div>
                 </div>
-                <div className="rounded-2xl border border-sky-200 bg-sky-50 p-4 text-xs text-sky-700 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100">
-                  <p className="font-semibold uppercase tracking-[0.3em]">next action</p>
-                  <p className="mt-2">Push summary + call slots to HubSpot, notify sales channel, log outcome to n8n.</p>
+                <div className={calloutClass}>
+                  <p className={isModern ? 'font-semibold uppercase tracking-[0.35em]' : 'font-semibold uppercase tracking-[0.3em]'}>next action</p>
+                  <p className={isModern ? 'mt-2 text-[13px] text-cyan-100/80' : 'mt-2 text-[13px]'}>Push summary + call slots to HubSpot, notify sales channel, log outcome to n8n.</p>
                 </div>
               </div>
             </div>
-            <div className="pointer-events-none absolute -inset-16 -z-10 bg-[radial-gradient(circle_at_center,rgba(56,189,248,0.25),transparent_65%)] dark:bg-[radial-gradient(circle_at_center,rgba(56,189,248,0.35),transparent_65%)]" />
+            <div
+              className={
+                isModern
+                  ? 'pointer-events-none absolute -inset-16 -z-10 bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.35),_transparent_65%)]'
+                  : 'pointer-events-none absolute -inset-16 -z-10 bg-[radial-gradient(circle_at_center,rgba(56,189,248,0.25),transparent_65%)] dark:bg-[radial-gradient(circle_at_center,rgba(56,189,248,0.35),transparent_65%)]'
+              }
+            />
           </motion.div>
         </div>
       </div>

--- a/frontend/src/components/Testimonials.tsx
+++ b/frontend/src/components/Testimonials.tsx
@@ -1,6 +1,7 @@
-﻿import React from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import SectionHeader from './SectionHeader';
+import { useDesign } from '../lib/design';
 
 const testimonials = [
   {
@@ -24,6 +25,16 @@ const testimonials = [
 ];
 
 const Testimonials: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const cardClass = isModern
+    ? 'flex h-full flex-col justify-between rounded-3xl border border-cyan-500/40 bg-slate-900/70 p-6 text-left text-slate-100 shadow-lg shadow-cyan-500/20 backdrop-blur'
+    : 'flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 text-left shadow-lg shadow-slate-200/60 dark:border-white/10 dark:bg-slate-900/60 dark:shadow-black/20';
+  const quoteClass = isModern ? 'text-sm leading-relaxed text-slate-200/80' : 'text-sm leading-relaxed text-slate-700 dark:text-slate-200';
+  const nameClass = isModern ? 'font-semibold text-cyan-100' : 'font-semibold text-slate-900 dark:text-slate-100';
+  const roleClass = isModern ? 'text-xs text-slate-400' : 'text-xs text-slate-500 dark:text-slate-400';
+
   return (
     <section id="testimonials" className="mx-auto max-w-6xl px-6">
       <div className="space-y-12">
@@ -40,12 +51,12 @@ const Testimonials: React.FC = () => {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ delay: index * 0.1, duration: 0.6, ease: 'easeOut' }}
-              className="flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 text-left shadow-lg shadow-slate-200/60 dark:border-white/10 dark:bg-slate-900/60 dark:shadow-black/20"
+              className={cardClass}
             >
-              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">"{testimonial.quote}"</p>
-              <footer className="mt-6 text-sm text-slate-500 dark:text-slate-400">
-                <p className="font-semibold text-slate-900 dark:text-slate-100">{testimonial.name}</p>
-                <p>{testimonial.role}</p>
+              <p className={quoteClass}>"{testimonial.quote}"</p>
+              <footer className="mt-6 text-sm">
+                <p className={nameClass}>{testimonial.name}</p>
+                <p className={roleClass}>{testimonial.role}</p>
               </footer>
             </motion.blockquote>
           ))}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,15 +1,18 @@
-﻿import React from 'react';
+import React from 'react';
 import { useTheme } from '../lib/theme';
+import { useDesign } from '../lib/design';
 
 const ThemeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
+  const buttonClass = isModern
+    ? 'inline-flex items-center gap-1.5 rounded-full border border-cyan-500/40 bg-slate-950/70 px-3 py-1.5 text-[11px] font-semibold text-cyan-100 shadow-lg shadow-cyan-500/20 transition hover:border-cyan-300 hover:text-cyan-50 focus:outline-none focus:ring focus:ring-cyan-500/40'
+    : 'inline-flex items-center gap-1.5 rounded-full border border-slate-300/60 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 shadow-sm transition hover:border-sky-400 hover:text-sky-600 focus:outline-none focus:ring focus:ring-sky-500/30 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-200';
 
   return (
-    <button
-      type="button"
-      onClick={toggleTheme}
-      className="inline-flex items-center gap-1.5 rounded-full border border-slate-300/60 bg-white px-3 py-1.5 text-[11px] font-semibold text-slate-700 shadow-sm transition hover:border-sky-400 hover:text-sky-600 focus:outline-none focus:ring focus:ring-sky-500/30 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-200"
-    >
+    <button type="button" onClick={toggleTheme} className={buttonClass}>
       <span className="sr-only">Toggle theme</span>
       {theme === 'light' ? <MoonIcon /> : <SunIcon />}
       <span>{theme === 'light' ? 'Dark mode' : 'Light mode'}</span>
@@ -56,4 +59,3 @@ const MoonIcon: React.FC = () => (
 );
 
 export default ThemeToggle;
-

--- a/frontend/src/components/UseCaseLauncher.tsx
+++ b/frontend/src/components/UseCaseLauncher.tsx
@@ -1,5 +1,6 @@
-﻿import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useDesign } from '../lib/design';
 
 interface UseCaseItem {
   component: string;
@@ -58,6 +59,9 @@ const useCases: UseCaseItem[] = [
 ];
 
 const UseCaseLauncher: React.FC = () => {
+  const { design } = useDesign();
+  const isModern = design === 'modern-programmer';
+
   const [isOpen, setIsOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
 
@@ -96,8 +100,30 @@ const UseCaseLauncher: React.FC = () => {
     [closePanel],
   );
 
+  const panelClass = isModern
+    ? 'pointer-events-auto flex w-[320px] flex-col rounded-3xl border border-cyan-500/40 bg-slate-950/90 p-5 text-sm text-slate-100 shadow-2xl shadow-cyan-500/30 backdrop-blur'
+    : 'pointer-events-auto flex w-[320px] flex-col rounded-3xl border border-slate-200 bg-white p-5 text-sm text-slate-800 shadow-2xl shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-950/95 dark:text-slate-100';
+  const toggleClass = isModern
+    ? 'pointer-events-auto inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 via-emerald-400 to-cyan-500 px-4 py-2 text-xs font-semibold text-slate-900 shadow-lg shadow-cyan-500/30 transition hover:from-cyan-300 hover:to-emerald-400 focus:outline-none focus:ring focus:ring-cyan-500/40'
+    : 'pointer-events-auto inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-lg shadow-slate-500/30 transition hover:bg-slate-800 focus:outline-none focus:ring focus:ring-slate-500/30 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100';
+  const cardClass = isModern
+    ? 'group w-full rounded-2xl border border-cyan-500/30 bg-slate-950/60 px-4 py-3 text-left transition hover:border-cyan-400 hover:bg-slate-950/80'
+    : 'group w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition hover:border-sky-400 hover:bg-sky-50/60 dark:border-white/10 dark:bg-slate-900/80 dark:hover:border-sky-400/60 dark:hover:bg-slate-900';
+  const componentLabelClass = isModern
+    ? 'text-[11px] font-semibold uppercase tracking-[0.35em] text-cyan-200'
+    : 'text-[11px] font-semibold uppercase tracking-[0.25em] text-slate-500 dark:text-slate-400';
+  const titleClass = isModern
+    ? 'mt-1 text-base font-semibold text-cyan-100 transition group-hover:text-cyan-200'
+    : 'mt-1 text-base font-semibold text-slate-900 transition group-hover:text-sky-600 dark:text-white dark:group-hover:text-sky-300';
+  const descriptionClass = isModern
+    ? 'mt-2 text-xs text-slate-400 transition group-hover:text-slate-300'
+    : 'mt-2 text-xs text-slate-600 transition group-hover:text-slate-700 dark:text-slate-400 dark:group-hover:text-slate-200';
+  const ctaClass = isModern
+    ? 'mt-3 inline-flex items-center text-xs font-semibold text-cyan-200 transition group-hover:text-cyan-100'
+    : 'mt-3 inline-flex items-center text-xs font-semibold text-sky-600 transition group-hover:text-sky-500 dark:text-sky-300 dark:group-hover:text-sky-200';
+
   return (
-    <div className="pointer-events-none fixed top-6 inset-x-0 z-50 flex flex-col items-center gap-3">
+    <div className="pointer-events-none fixed inset-x-0 top-6 z-50 flex flex-col items-center gap-3">
       <AnimatePresence>
         {isOpen && (
           <motion.div
@@ -107,46 +133,29 @@ const UseCaseLauncher: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.2, ease: 'easeOut' }}
-            className="pointer-events-auto flex w-[320px] flex-col rounded-3xl border border-slate-200 bg-white p-5 text-sm text-slate-800 shadow-2xl shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-950/95 dark:text-slate-100"
+            className={panelClass}
           >
             <div className="mb-4 space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-600 dark:text-sky-300">Use cases</p>
-              <h4 className="text-lg font-semibold text-slate-900 dark:text-white">Explore packaged components</h4>
-              <p className="text-xs text-slate-500 dark:text-slate-400">
+              <p className={componentLabelClass}>Use cases</p>
+              <h4 className={isModern ? 'text-lg font-semibold text-cyan-100' : 'text-lg font-semibold text-slate-900 dark:text-white'}>Explore packaged components</h4>
+              <p className={isModern ? 'text-xs text-slate-400' : 'text-xs text-slate-500 dark:text-slate-400'}>
                 Pick a component to open its experience. Add or edit entries in <code>UseCaseLauncher.tsx</code> as your library grows.
               </p>
             </div>
-            <div className="space-y-3 overflow-y-auto pr-1 max-h-[56vh]">
+            <div className="max-h-[56vh] space-y-3 overflow-y-auto pr-1">
               {useCases.map((useCase) => (
-                <button
-                  key={useCase.component}
-                  type="button"
-                  onClick={() => handleCaseClick(useCase.action)}
-                  className="group w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition hover:border-sky-400 hover:bg-sky-50/60 dark:border-white/10 dark:bg-slate-900/80 dark:hover:border-sky-400/60 dark:hover:bg-slate-900"
-                >
-                  <span className="text-[11px] font-semibold uppercase tracking-[0.25em] text-slate-500 dark:text-slate-400">
-                    {useCase.component}
-                  </span>
-                  <p className="mt-1 text-base font-semibold text-slate-900 transition group-hover:text-sky-600 dark:text-white dark:group-hover:text-sky-300">
-                    {useCase.title}
-                  </p>
-                  <p className="mt-2 text-xs text-slate-600 transition group-hover:text-slate-700 dark:text-slate-400 dark:group-hover:text-slate-200">
-                    {useCase.description}
-                  </p>
-                  <span className="mt-3 inline-flex items-center text-xs font-semibold text-sky-600 transition group-hover:text-sky-500 dark:text-sky-300 dark:group-hover:text-sky-200">
-                    {useCase.ctaLabel}
-                  </span>
+                <button key={useCase.component} type="button" onClick={() => handleCaseClick(useCase.action)} className={cardClass}>
+                  <span className={componentLabelClass}>{useCase.component}</span>
+                  <p className={titleClass}>{useCase.title}</p>
+                  <p className={descriptionClass}>{useCase.description}</p>
+                  <span className={ctaClass}>{useCase.ctaLabel}</span>
                 </button>
               ))}
             </div>
           </motion.div>
         )}
       </AnimatePresence>
-      <button
-        type="button"
-        onClick={() => setIsOpen((prev) => !prev)}
-        className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-lg shadow-slate-500/30 transition hover:bg-slate-800 focus:outline-none focus:ring focus:ring-slate-500/30 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
-      >
+      <button type="button" onClick={() => setIsOpen((prev) => !prev)} className={toggleClass}>
         {isOpen ? 'Hide use cases' : 'Use case launcher'}
       </button>
     </div>
@@ -154,7 +163,3 @@ const UseCaseLauncher: React.FC = () => {
 };
 
 export default UseCaseLauncher;
-
-
-
-

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,16 @@ body {
   @apply bg-slate-950 text-slate-100;
 }
 
+body[data-design='modern-programmer'] {
+  background-color: #020617;
+  color: rgb(226 232 240);
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Menlo', monospace;
+}
+
 * {
   font-family: 'Inter', sans-serif;
+}
+
+body[data-design='modern-programmer'] * {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Menlo', monospace;
 }

--- a/frontend/src/lib/design.tsx
+++ b/frontend/src/lib/design.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type DesignStyle = 'classic' | 'modern-programmer';
+
+interface DesignContextValue {
+  design: DesignStyle;
+  setDesign: (design: DesignStyle) => void;
+}
+
+const STORAGE_KEY = 'workflow-sg-design-style';
+
+const DesignContext = createContext<DesignContextValue | undefined>(undefined);
+
+function getInitialDesign(): DesignStyle {
+  if (typeof window === 'undefined') {
+    return 'classic';
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'classic' || stored === 'modern-programmer') {
+    return stored;
+  }
+
+  return 'classic';
+}
+
+export const DesignProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [design, setDesignState] = useState<DesignStyle>(() => getInitialDesign());
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.documentElement.dataset.design = design;
+    document.body.dataset.design = design;
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, design);
+    }
+
+    return () => {
+      delete document.documentElement.dataset.design;
+      delete document.body.dataset.design;
+    };
+  }, [design]);
+
+  const setDesign = useCallback((nextDesign: DesignStyle) => {
+    setDesignState(nextDesign);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      design,
+      setDesign,
+    }),
+    [design, setDesign],
+  );
+
+  return <DesignContext.Provider value={value}>{children}</DesignContext.Provider>;
+};
+
+export function useDesign(): DesignContextValue {
+  const context = useContext(DesignContext);
+  if (!context) {
+    throw new Error('useDesign must be used within a DesignProvider');
+  }
+  return context;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,11 +6,14 @@ import '@fontsource/inter/600.css';
 import '@fontsource/inter/700.css';
 import './index.css';
 import { ThemeProvider } from './lib/theme';
+import { DesignProvider } from './lib/design';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <App />
+      <DesignProvider>
+        <App />
+      </DesignProvider>
     </ThemeProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- introduce a design context and selector to toggle between the existing style and a modern programmer aesthetic
- restyle the hero, feature, showcase, testimonials, CTA, and chat surfaces to react to the active design
- update auxiliary components (admin tools, floating chat, footer, theme toggle) and global styling so both designs feel cohesive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2649e78bc8328b03cab31a3db95ce