### PR TITLE
feat: add web research agent workflow panel

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import express from 'express';
 import { run, user, assistant } from '@openai/agents';
 import { agent } from './agent.js';
+import { runWorkflow as runWebResearchWorkflow } from './workflows/webResearchWorkflow.js';
 
 const app = express();
 const port = Number.parseInt(process.env.PORT, 10) || 3000;
@@ -46,6 +47,25 @@ app.post('/api/chat', async (req, res, next) => {
     }
 
     res.json({ answer, citations: [] });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post('/api/workflows/web-research', async (req, res, next) => {
+  try {
+    const inputText = typeof req.body?.input_as_text === 'string' ? req.body.input_as_text.trim() : '';
+
+    if (!inputText) {
+      const error = new Error('input_as_text is required');
+      error.status = 400;
+      error.code = 'BAD_REQUEST';
+      throw error;
+    }
+
+    const result = await runWebResearchWorkflow({ input_as_text: inputText });
+
+    res.json({ ok: true, result });
   } catch (error) {
     next(error);
   }

--- a/backend/src/workflows/webResearchWorkflow.js
+++ b/backend/src/workflows/webResearchWorkflow.js
@@ -1,0 +1,119 @@
+import { z } from 'zod';
+import { Agent, Runner } from '@openai/agents';
+
+const WebResearchAgentSchema = z.object({
+  companies: z.array(
+    z.object({
+      company_name: z.string(),
+      industry: z.string(),
+      headquarters_location: z.string(),
+      company_size: z.string(),
+      website: z.string(),
+      description: z.string(),
+      founded_year: z.number(),
+    }),
+  ),
+});
+
+const SummarizeAndDisplaySchema = z.object({
+  company_name: z.string(),
+  industry: z.string(),
+  headquarters_location: z.string(),
+  company_size: z.string(),
+  website: z.string(),
+  description: z.string(),
+  founded_year: z.number(),
+});
+
+const webResearchAgent = new Agent({
+  name: 'Web research agent',
+  instructions:
+    'You are a helpful assistant. Use web search to find information about the following company I can use in marketing asset based on the underlying topic.',
+  model: 'gpt-5-mini',
+  outputType: WebResearchAgentSchema,
+  modelSettings: {
+    reasoning: {
+      effort: 'low',
+      summary: 'auto',
+    },
+    store: true,
+  },
+});
+
+const summarizeAndDisplay = new Agent({
+  name: 'Summarize and display',
+  instructions: 'Put the research together in a nice display using the output format described.\n',
+  model: 'gpt-5',
+  outputType: SummarizeAndDisplaySchema,
+  modelSettings: {
+    reasoning: {
+      effort: 'minimal',
+      summary: 'auto',
+    },
+    store: true,
+  },
+});
+
+export const runWorkflow = async ({ input_as_text }) => {
+  if (!input_as_text || typeof input_as_text !== 'string') {
+    const error = new Error('Expected input_as_text to be a non-empty string');
+    error.code = 'INVALID_INPUT';
+    throw error;
+  }
+
+  const conversationHistory = [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: input_as_text,
+        },
+      ],
+    },
+  ];
+
+  const runner = new Runner({
+    traceMetadata: {
+      __trace_source__: 'agent-builder',
+      workflow_id: 'wf_68e7384825dc8190bd14567ebc5132510af21f2af2290200',
+    },
+  });
+
+  const webResearchAgentResultTemp = await runner.run(webResearchAgent, [...conversationHistory]);
+
+  if (!webResearchAgentResultTemp?.finalOutput) {
+    const error = new Error('Web research agent result is undefined');
+    error.code = 'WEB_RESEARCH_AGENT_ERROR';
+    throw error;
+  }
+
+  const newItems = Array.isArray(webResearchAgentResultTemp.newItems)
+    ? webResearchAgentResultTemp.newItems
+    : [];
+
+  conversationHistory.push(...newItems.map((item) => item.rawItem).filter(Boolean));
+
+  const webResearchAgentResult = {
+    output_text: JSON.stringify(webResearchAgentResultTemp.finalOutput),
+    output_parsed: webResearchAgentResultTemp.finalOutput,
+  };
+
+  const summarizeAndDisplayResultTemp = await runner.run(summarizeAndDisplay, [...conversationHistory]);
+
+  if (!summarizeAndDisplayResultTemp?.finalOutput) {
+    const error = new Error('Summarize and display agent result is undefined');
+    error.code = 'SUMMARIZE_AGENT_ERROR';
+    throw error;
+  }
+
+  const summarizeAndDisplayResult = {
+    output_text: JSON.stringify(summarizeAndDisplayResultTemp.finalOutput),
+    output_parsed: summarizeAndDisplayResultTemp.finalOutput,
+  };
+
+  return {
+    webResearchAgentResult,
+    summarizeAndDisplayResult,
+  };
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Hero from './components/Hero';
 import Features from './components/Features';
 import Showcase from './components/Showcase';
 import ChatPanel from './components/ChatPanel';
+import WebResearchAgentPanel from './components/WebResearchAgentPanel';
 import Testimonials from './components/Testimonials';
 import CTA from './components/CTA';
 import Footer from './components/Footer';
@@ -39,6 +40,7 @@ const App: React.FC = () => {
         <Component />
         <Features />
         <Showcase />
+        <WebResearchAgentPanel />
         <ChatPanel />
         <Testimonials />
         <CTA />

--- a/frontend/src/components/WebResearchAgentPanel.d.ts
+++ b/frontend/src/components/WebResearchAgentPanel.d.ts
@@ -1,0 +1,4 @@
+import type { FC } from 'react';
+
+declare const WebResearchAgentPanel: FC;
+export default WebResearchAgentPanel;

--- a/frontend/src/components/WebResearchAgentPanel.jsx
+++ b/frontend/src/components/WebResearchAgentPanel.jsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react';
+
+const API_BASE_URL = normalizeBaseUrl(import.meta.env.VITE_API_BASE_URL);
+
+const WebResearchAgentPanel = () => {
+  const [query, setQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [result, setResult] = useState(null);
+
+  const formattedSummary = useMemo(() => {
+    if (!result?.summarizeAndDisplayResult?.output_parsed) {
+      return null;
+    }
+
+    return result.summarizeAndDisplayResult.output_parsed;
+  }, [result]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed || isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/workflows/web-research`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ input_as_text: trimmed }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: { msg: 'Unable to reach workflow service' } }));
+        const message = data?.error?.msg || 'Unable to reach workflow service';
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      setResult(data.result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unexpected error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <section className="mx-auto max-w-5xl px-6">
+      <div className="overflow-hidden rounded-[32px] border border-slate-200 bg-white/80 shadow-xl shadow-slate-200/70 backdrop-blur dark:border-white/10 dark:bg-slate-900/70 dark:shadow-sky-500/20">
+        <div className="grid gap-10 p-8 lg:grid-cols-[1fr_1fr]">
+          <div className="space-y-6">
+            <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">Web research workflow</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Run the two-step agent workflow powered by the OpenAI Agents API. The first agent researches the company, and the second agent produces a marketing-ready summary.
+            </p>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <label htmlFor="web-research-query" className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">
+                Company prompt
+              </label>
+              <textarea
+                id="web-research-query"
+                className="h-28 w-full resize-none rounded-3xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none focus:ring focus:ring-sky-400/20 dark:border-white/10 dark:bg-slate-900/80 dark:text-white dark:placeholder:text-slate-500"
+                placeholder="Research marketing angles for Workflow SG in Singapore."
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                disabled={isLoading}
+              />
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="inline-flex items-center justify-center rounded-full bg-sky-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoading ? 'Running workflow…' : 'Run workflow'}
+              </button>
+              {error && <p className="text-xs text-rose-500 dark:text-rose-300">{error}</p>}
+            </form>
+          </div>
+          <div className="space-y-6">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-300">Workflow output</h4>
+              <span className="text-xs text-slate-500">Powered by @openai/agents</span>
+            </div>
+            <div className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 text-sm text-slate-700 shadow-sm dark:border-white/10 dark:bg-slate-950/60 dark:text-slate-200">
+              {isLoading && <p>Agents are gathering information…</p>}
+              {!isLoading && formattedSummary && (
+                <div className="space-y-3">
+                  <p className="text-base font-semibold text-slate-900 dark:text-white">{formattedSummary.company_name}</p>
+                  <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+                    <span>{formattedSummary.industry}</span>
+                    <span>•</span>
+                    <span>{formattedSummary.headquarters_location}</span>
+                    <span>•</span>
+                    <span>Founded {formattedSummary.founded_year}</span>
+                  </div>
+                  <p className="leading-relaxed text-slate-600 dark:text-slate-300">{formattedSummary.description}</p>
+                  <div className="flex flex-wrap gap-4 text-xs text-sky-600 dark:text-sky-300">
+                    <a href={formattedSummary.website} target="_blank" rel="noreferrer" className="underline underline-offset-2">
+                      Visit website
+                    </a>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                      {formattedSummary.company_size}
+                    </span>
+                  </div>
+                </div>
+              )}
+              {!isLoading && !formattedSummary && !error && <p className="text-slate-500 dark:text-slate-500">Run the workflow to see structured results here.</p>}
+            </div>
+            {result?.webResearchAgentResult?.output_parsed?.companies?.length > 0 && (
+              <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-50/70 p-6 text-xs leading-relaxed text-slate-600 dark:border-white/10 dark:bg-slate-900/50 dark:text-slate-300">
+                <p className="mb-2 font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Raw research</p>
+                <pre className="max-h-52 overflow-y-auto whitespace-pre-wrap text-[11px] text-slate-600 dark:text-slate-300">
+                  {JSON.stringify(result.webResearchAgentResult.output_parsed, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+function normalizeBaseUrl(raw) {
+  if (!raw) {
+    return '';
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === '/') {
+    return '';
+  }
+  return trimmed.replace(/\/$/, '');
+}
+
+export default WebResearchAgentPanel;


### PR DESCRIPTION
## Summary
- add a web research workflow runner that composes the research and summary agents on the backend
- expose a `/api/workflows/web-research` endpoint for the frontend to trigger the workflow
- build a WebResearchAgentPanel component that calls the backend workflow and display results in the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec57eb7fb48328bedffd0e655b71b1