### PR TITLE
fix: ensure public dir available for docker build

### DIFF
--- a/my-chatkit-app/public/.gitkeep
+++ b/my-chatkit-app/public/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to ensure Next.js public directory exists for Docker builds.


### PR DESCRIPTION
## Summary
- add a placeholder file so the Next.js public directory exists during Docker builds

## Testing
- ⚠️ `docker build -t chatkit .` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf27f6a0083288a0ba7557f3aa55e